### PR TITLE
Added python dependencies for pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib==2.0.0
+numpy==1.12.1
+prettytable==0.7.2
+PyQt5==5.8.2


### PR DESCRIPTION
It is better to store dependencies information in separate file also, so that you can run `pip3 install -r filename` to install all dependencies at once.